### PR TITLE
fix: device rediscovery issue when name changes

### DIFF
--- a/WiimotePair/ViewController.m
+++ b/WiimotePair/ViewController.m
@@ -95,6 +95,8 @@
 - (void)deviceInquiryDeviceFound:(IOBluetoothDeviceInquiry*)sender device:(IOBluetoothDevice*)device {
     // Skip unsupported devices.
     if (![device.name containsString:@"Nintendo RVL-CNT-01"]) {
+        // Clear devices to enable rediscovery if the name changes.
+        [_deviceInquiry clearFoundDevices];
         return;
     }
     


### PR DESCRIPTION
## Summary: Addressing Device Rediscovery Bug
This merge request resolves a bug that prevents devices from being processed correctly when they are rediscovered with their correct names. Previously, when a device was found with an incorrect name, the system would not handle it properly during subsequent rediscovery attempts.

## Issue Details
In approximately 50% of cases, the `deviceInquiryDeviceFound` function is called with the device name being a MAC address: "Found peer <CBClassicPeer: 0xXXXXXXXXX XXXXXXXXXXXXXXXX, **XX:XX:XX:XX:XX:XX**" instead of the expected: "Found peer <CBClassicPeer: 0xXXXXXXXXX XXXXXXXXXXXXXXXX, **Nintendo RVL-CNT-01**".

When the sync continues and the correct name for the device is found, the `deviceInquiryDeviceFound` doesn't get retriggered because the device is in the found devices list. You have to restart the app for it to work again.

## Proposed Solution
I suggest clearing the list of found devices after the device is skipped. With a build with this fix I can connect to the wiimote 100% of the times instead of the previous 50%.